### PR TITLE
Update libasync dependency to 0.8.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,7 +10,7 @@
     "targetPath": "build",
     "workingDirectory": "build",
     "dependencies": {
-        "libasync": "~>0.7.9"
+        "libasync": "~>0.8.0"
     },
     "configurations": [
         {

--- a/src/asynchronous/libasync/events.d
+++ b/src/asynchronous/libasync/events.d
@@ -20,7 +20,7 @@ import libasync.events : EventLoop_ = EventLoop, NetworkAddress;
 import libasync.signal : AsyncSignal;
 import libasync.timer : AsyncTimer;
 import libasync.tcp : AsyncTCPConnection, AsyncTCPListener, TCPEvent;
-import libasync.threads : destroyAsyncThreads, gs_threads;
+import libasync.threads : destroyAsyncThreads;
 import libasync.udp : AsyncUDPSocket, UDPEvent;
 import asynchronous.events;
 import asynchronous.futures;


### PR DESCRIPTION
libasync 0.7.9 doesn't work with dmd 2.072.0 beta.

0.7.9 causes:

```
Running ./asynchronous 
object.Error@src/rt/minfo.d(356): Cyclic dependency between module libasync.threads and libasync.posix
libasync.threads* ->
libasync.events ->
libasync.posix* ->
libasync.events ->
libasync.threads*

Program exited with code -11
```
