### PR TITLE
Update libasync dependency to 0.8.2

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,7 +10,7 @@
     "targetPath": "build",
     "workingDirectory": "build",
     "dependencies": {
-        "libasync": "~>0.8.0"
+        "libasync": "~>0.8.2"
     },
     "configurations": [
         {


### PR DESCRIPTION
I hope it is the last request to update the libasync dependency because of dmd 2.072.0. The problem this time is memutils. libasync 0.8.0 depends on an elder memutils, which doesn't build: https://github.com/etcimon/libasync/pull/72

Therefore would be nice to update libasync now to 0.8.2 and make a new minor asynchronous release if possible. Thanks.